### PR TITLE
feat: 在使用备用路线前先检测备用路线版本是否最新

### DIFF
--- a/中文git.py
+++ b/中文git.py
@@ -66,7 +66,7 @@ def download_update_file(version):
         return new_filename
     except Exception as e:
         print(f"{Fore.RED}✕{Fore.RESET} 下载更新文件时出错: {e}")
-        choice = input(f"{Fore.BLUE}?{Fore.RESET} 是否切换备用下载路线(是/否):").lower()
+        choice = input(f"{Fore.BLUE}?{Fore.RESET} 是否切换备用下载路线(是/否): ").lower()
         if choice in ['是', 'y', 'yes']:
             try:
                 spare_download_version = requests.get(spare_download_version_url)


### PR DESCRIPTION
@fjwxzde set

---

具体做法就是在备用路线上放个`info.json`，然后获取其中的`version`键值来和GitHub API上的json的版本比较，不一样则不予下载，并提醒提交Issue。